### PR TITLE
added `vaddr_t` type (CHERI-specific)

### DIFF
--- a/frontend/model/ail/ailTypesAux.lem
+++ b/frontend/model/ail/ailTypesAux.lem
@@ -45,6 +45,8 @@ let rec is_signed_ity ity =
     | Ptrdiff_t ->
         (* STD §7.19#2 *)
         true
+    | Vaddr_t ->
+        false
   end
 
 (* STD §6.2.5#6, sentence 4 *)
@@ -385,6 +387,7 @@ let le_integer_range impl ity1 ity2 =
   | (Size_t, Size_t) -> true
   | (Wchar_t, Wchar_t) -> true
   | (Ptrdiff_t, Ptrdiff_t) -> true
+  | (Vaddr_t, Vaddr_t) -> true
   | (Enum _, Enum _) ->
       (* impossible *)
       error "le_integer_range: Enum, Enum"
@@ -393,6 +396,8 @@ let le_integer_range impl ity1 ity2 =
       error "WIP le_integer_range: Char, Size_t"
   | (Char, Ptrdiff_t) ->
       error "WIP le_integer_range: Char, Ptrdiff_t"
+  | (Char, Vaddr_t) ->
+      error "WIP le_integer_range: Char, Vaddr_t"
   | (Char, Enum _) ->
       error "WIP le_integer_range: Char, Enum"
   
@@ -400,6 +405,8 @@ let le_integer_range impl ity1 ity2 =
       error "WIP le_integer_range: Bool, Size_t"
   | (Bool, Ptrdiff_t) ->
       error "WIP le_integer_range: Bool, Ptrdiff_t"
+  | (Bool, Vaddr_t) ->
+      error "WIP le_integer_range: Bool, Vaddr_t"
   | (Bool, Enum _) ->
       (* impossible *)
       error "le_integer_range: Bool, Enum"
@@ -408,6 +415,8 @@ let le_integer_range impl ity1 ity2 =
       error "WIP le_integer_range: Signed, Size_t"
   | (Signed _, Ptrdiff_t) ->
       error "WIP le_integer_range: Signed, Ptrdiff_t"
+  | (Signed _, Vaddr_t) ->
+      error "WIP le_integer_range: Signed, Vaddr_t"
   | (Signed _, Enum _) ->
       (* impossible *)
       error "le_integer_range: Signed, Enum"
@@ -416,6 +425,8 @@ let le_integer_range impl ity1 ity2 =
       error "WIP le_integer_range: Unsigned, Size_t"
   | (Unsigned _, Ptrdiff_t) ->
       error "WIP le_integer_range: Unsigned, Ptrdiff_t"
+  | (Unsigned _, Vaddr_t) ->
+      error "WIP le_integer_range: Unsigned, Vaddr_t"
   | (Unsigned _, Enum _) ->
       (* impossible *)
       error "le_integer_range: Unsigned, Enum"
@@ -433,7 +444,25 @@ let le_integer_range impl ity1 ity2 =
       error "le_integer_range: Ptrdiff_t, Enum"
   | (Ptrdiff_t, Size_t) ->
       error "WIP le_integer_range: Ptrdiff_t, Size_t"
-  
+  | (Ptrdiff_t, Vaddr_t) ->
+      error "WIP le_integer_range: Ptrdiff_t, Vaddr_t"
+
+  | (Vaddr_t, Char) ->
+      error "WIP le_integer_range: Vaddr_t, Char"
+  | (Vaddr_t, Bool) ->
+      error "WIP le_integer_range: Vaddr_t, Bool"
+  | (Vaddr_t, Signed _) ->
+      error "WIP le_integer_range: Vaddr_t, Signed"
+  | (Vaddr_t, Unsigned _) ->
+      error "WIP le_integer_range: Vaddr_t, Unsigned"
+  | (Vaddr_t, Enum _) ->
+      (* impossible *)
+      error "le_integer_range: Vaddr_t, Enum"
+  | (Vaddr_t, Size_t) ->
+      error "WIP le_integer_range: Vaddr_t, Size_t"
+  | (Vaddr_t, Ptrdfiff_t) ->
+      error "WIP le_integer_range: Vaddr_t, Ptrdiff_t"
+
   | (Size_t, Char) ->
       error "WIP le_integer_range: Size_t, Char"
   | (Size_t, Bool) ->
@@ -447,7 +476,9 @@ let le_integer_range impl ity1 ity2 =
       error "le_integer_range: Size_t, Enum"
   | (Size_t, Ptrdiff_t) ->
       error "WIP le_integer_range: Size_t, Ptrdiff_t"
-  
+  | (Size_t, Vaddr_t) ->
+      error "WIP le_integer_range: Size_t, Vaddr_t"
+
   | (Enum _, Char) ->
       (* impossible *)
       error "le_integer_range: Enum, Char"
@@ -466,6 +497,9 @@ let le_integer_range impl ity1 ity2 =
   | (Enum _, Ptrdiff_t) ->
       (* impossible *)
       error "le_integer_range: Enum, Ptrdiff_t"
+  | (Enum _, Vaddr_t) ->
+      (* impossible *)
+      error "le_integer_range: Enum, Vaddr_t"
 
   | (Wchar_t, _) ->
       error "WIP le_integer_range: wchar_t"

--- a/frontend/model/ail/genTypes.lem
+++ b/frontend/model/ail/genTypes.lem
@@ -4,6 +4,7 @@ type genIntegerType [name="git*"] =
  | Concrete of integerType
  | SizeT
  | PtrdiffT
+ | VaddrT
  | Unknown of integerConstant
  | Promote of genIntegerType
  | Usual of genIntegerType * genIntegerType
@@ -58,12 +59,14 @@ let rec eq_genIntegerType gity1 gity2 =
         1
     | PtrdiffT ->
         2
-    | Unknown _ ->
+    | VaddrT ->
         3
-    | Promote _ ->
+    | Unknown _ ->
         4
-    | Usual _ _ ->
+    | Promote _ ->
         5
+    | Usual _ _ ->
+        6
   end in
   match (gity1, gity2) with
     | (Concrete ity1, Concrete ity2) ->

--- a/frontend/model/ail/genTypesAux.lem
+++ b/frontend/model/ail/genTypesAux.lem
@@ -260,6 +260,8 @@ let rec interpret_genIntegerType loc impl git : errorM integerType =
       return Size_t
   | PtrdiffT ->
       return Ptrdiff_t
+  | VaddrT ->
+      return Vaddr_t
   | Unknown ic ->
       AilTyping.type_of_constant loc impl ic
   | Promote git ->

--- a/frontend/model/ail/integerImpl.lem
+++ b/frontend/model/ail/integerImpl.lem
@@ -39,16 +39,18 @@ type implementation = <|
   impl_precision:   integerType -> nat;
   impl_size_t:      integerType;
   impl_ptrdiff_t:   integerType;
+  impl_vaddr_t  :   integerType;
 |>
 
 val make_implementation: binaryMode -> (integerType -> bool) -> (integerType -> nat)
-                         -> integerType -> integerType -> implementation
-let make_implementation binary_mode signed precision size_ity ptrdiff_ity = <|
+                         -> integerType -> integerType -> integerType -> implementation
+let make_implementation binary_mode signed precision size_ity ptrdiff_ity vaddr_ity = <|
   impl_binary_mode= binary_mode;
   impl_signed=      signed;
   impl_precision=   precision;
   impl_size_t=      size_ity;
-  impl_ptrdiff_t=   ptrdiff_ity
+  impl_ptrdiff_t=   ptrdiff_ity;
+  impl_vaddr_t=     vaddr_ity;
 |>
 
 val integer_range: implementation -> integerType -> range
@@ -89,6 +91,7 @@ let min_integer_range = function
   | Wchar_t -> error "TODO: min_integer_range, Wchar_t"
   | Wint_t -> error "TODO: min_integer_range, Wint_t"
   | Ptrdiff_t -> error "TODO: min_integer_range, Ptrdiff_t"
+  | Vaddr_t -> error "TODO: min_integer_range, Vaddr_t"
 end
 
 val min_implementation_signed_char: implementation
@@ -106,6 +109,7 @@ let min_implementation_signed_char =
         | Wchar_t -> error "TODO: min_implementation_signed_char, Wchar_t 1"
         | Wint_t -> error "TODO: min_implementation_signed_char, Wint_t 1"
         | Ptrdiff_t -> error "TODO: min_implementation_signed_char, Ptrdiff_t 1"
+        | Vaddr_t -> error "TODO: min_implementation_signed_char, Vaddr_t 1"
       end
     )
     ( function
@@ -145,10 +149,12 @@ let min_implementation_signed_char =
         | Wchar_t -> error "TODO: min_implementation_signed_char, Wchar_t 2"
         | Wint_t -> error "TODO: min_implementation_signed_char, Wint_t 2"
         | Ptrdiff_t -> error "TODO: min_implementation_signed_char, Ptrdiff_t 2"
+        | Vaddr_t -> error "TODO: min_implementation_signed_char, Vaddr_t 2"
       end
     )
     (Unsigned Long)
     (Signed   Long)
+    (Unsigned Long)
 
 val min_implementation_unsigned_char: implementation
 let min_implementation_unsigned_char =
@@ -165,6 +171,7 @@ let min_implementation_unsigned_char =
         | Wchar_t -> error "TODO: min_implementation_unsigned_char, Wchar_t 1"
         | Wint_t -> error "TODO: min_implementation_unsigned_char, Wint_t 1"
         | Ptrdiff_t -> error "TODO: min_implementation_unsigned_char, Ptrdiff_t 1"
+        | Vaddr_t -> error "TODO: min_implementation_unsigned_char, Vaddr_t 1"
       end
     )
     ( function
@@ -204,8 +211,9 @@ let min_implementation_unsigned_char =
         | Wchar_t -> error "TODO: min_implementation_unsigned_char, Wchar_t 2"
         | Wint_t -> error "TODO: min_implementation_unsigned_char, Wint_t 2"
         | Ptrdiff_t -> error "TODO: min_implementation_unsigned_char, Ptrdiff_t 2"
+        | Vaddr_t -> error "TODO: min_implementation_unsigned_char, Vaddr_t 2"
       end
     )
     (Unsigned Long)
     (Signed   Long)
-
+    (Unsigned Long)

--- a/frontend/model/builtins.lem
+++ b/frontend/model/builtins.lem
@@ -39,6 +39,8 @@ let translate_builtin_typenames = function
       Just intptr_t
   | "__cerbty_ptrdiff_t" ->
       Just ptrdiff_t
+  | "__cerbty_vaddr_t" ->
+      Just vaddr_t
   | "__cerbty_uint8_t" ->
       Just (mk_ctype_integer (Unsigned (IntN_t 8)))
   | "__cerbty_uint16_t" ->
@@ -402,6 +404,10 @@ let translate_builtin_varnames (Symbol.Identifier _ str) =
         const_int $ IConstantMin Ptrdiff_t
     | "__cerbvar_PTRDIFF_MAX" ->
         const_int $ IConstantMax Ptrdiff_t
+    | "__cerbvar_VADDR_MIN" ->
+        const_int $ IConstantMin Vaddr_t
+    | "__cerbvar_VADDR_MAX" ->
+        const_int $ IConstantMax Vaddr_t
     | "__cerbvar_INT_LEAST8_MIN" ->
         const_int $ IConstantMin (Signed (Int_leastN_t 8))
     | "__cerbvar_INT_LEAST16_MIN" ->

--- a/frontend/model/ctype.lem
+++ b/frontend/model/ctype.lem
@@ -31,6 +31,7 @@ type integerType (* [name = "^\\(\\|\\([a-z A-Z]+_\\)\\)ity[0-9]*'?$"] *) =
  | Wint_t
  | Size_t
  | Ptrdiff_t
+ | Vaddr_t (* CHERI-specific *)
 
 (* STD §6.2.5#10, sentence 1 *)
 type realFloatingType =
@@ -165,6 +166,8 @@ let integerTypeEqual ity1 ity2 =
         7
     | Ptrdiff_t ->
         8
+    | Vaddr_t ->
+        9
   end in
   match (ity1, ity2) with
     | (Signed ibty1, Signed ibty2) ->
@@ -335,7 +338,9 @@ let setElemCompare_integerType ity1 ity2 =
         7
     | Ptrdiff_t ->
         8
-  end in
+    | Vaddr_t ->
+       9
+end in
   match (ity1, ity2) with
     | (Signed ibty1, Signed ibty2) ->
         setElemCompare ibty1 ibty2
@@ -551,6 +556,10 @@ let size_t =
 val ptrdiff_t: ctype
 let ptrdiff_t =
   Ctype [] (Basic (Integer Ptrdiff_t))
+
+val vaddr_t: ctype
+let vaddr_t =
+  Ctype [] (Basic (Integer Vaddr_t))
 
 val is_ptr_t: ctype -> bool
 let is_ptr_t (Ctype _ ty_) =

--- a/frontend/model/defacto_memory.lem
+++ b/frontend/model/defacto_memory.lem
@@ -205,6 +205,8 @@ let defacto_integer_range = function
      (0-2147483648, 2147483647)
  | Ptrdiff_t ->
      (0-2**63, 2**63-1)
+ | Vaddr_t ->
+     (0, 2**64 - 1)
 end
 let inline integer_range = defacto_integer_range
 

--- a/frontend/model/defacto_memory_aux.lem
+++ b/frontend/model/defacto_memory_aux.lem
@@ -250,6 +250,8 @@ let rec simplify_integer_value_base ival_ =
                   | Nothing ->
                       Right ival_
                 end
+            | Vaddr_t ->
+               Left 0
             | Signed _ ->
                 match Implementation.sizeof_ity ity with
                   | Just n ->
@@ -286,6 +288,8 @@ let rec simplify_integer_value_base ival_ =
                       Left unsigned_max
                   | Ptrdiff_t ->
                       Left signed_max
+                  | Vaddr_t ->
+                      Left unsigned_max
                   | Signed _ ->
                       Left signed_max
                   | Enum _ ->

--- a/frontend/model/implementation.lem
+++ b/frontend/model/implementation.lem
@@ -33,6 +33,7 @@ let integerImpl () =
     )
     (Ctype.Size_t)
     (Ctype.Ptrdiff_t)
+    (Ctype.Vaddr_t)
 
 type implementation_constant =
   (* J.3.2 Environment *)

--- a/memory/cheri/impl_mem.ml
+++ b/memory/cheri/impl_mem.ml
@@ -2330,7 +2330,21 @@ module CHERI (C:Capability
                TyPred (Ctype.ctypeEqual Ctype.uintptr_t);
                TyIsPointer
            ];
+             ExactArg Ctype.size_t ] )
+   (*
+    else if name = "cheri_address_get" then
+      Some ( ExactRet (Ctype.vaddr_t)
+           [ PolymorphicArg [
+               TyPred (Ctype.ctypeEqual Ctype.intptr_t);
+               TyPred (Ctype.ctypeEqual Ctype.uintptr_t);
+               TyIsPointer
+           ];
            ExactArg Ctype.size_t ] )
+    else if name = "cheri_base_get" then
+    else if name = "cheri_length_get" then
+    else if name = "cheri_tag_get" then
+    else if name = "cheri_is_equal_exact" then
+   *)
     else
       None
 
@@ -2674,6 +2688,8 @@ module CHERI (C:Capability
                 | Wint_t (* TODO *)
                 | Signed _ ->
                  signed_max n
+              | Vaddr_t ->
+                 unsigned_max n
               | Enum _ ->
                  (* TODO: hack, assuming like int *)
                  signed_max 4
@@ -2709,6 +2725,7 @@ module CHERI (C:Capability
            | None ->
               failwith "the concrete memory model requires a complete implementation MIN"
            end
+        | Vaddr_t -> zero
         | Enum _ ->
            (* TODO: hack, assuming like int *)
            signed_min 4

--- a/memory/concrete/impl_mem.ml
+++ b/memory/concrete/impl_mem.ml
@@ -2182,6 +2182,8 @@ let eff_member_shift_ptrval _ tag_sym membr_ident ptrval =
             | Wint_t (* TODO *)
             | Signed _ ->
                 signed_max
+            | Vaddr_t ->
+                unsigned_max
             | Enum _ ->
                 (* TODO: hack, assuming like int *)
                 sub (pow_int (of_int 2) (8*4-1)) (of_int 1)
@@ -2214,6 +2216,7 @@ let eff_member_shift_ptrval _ tag_sym membr_ident ptrval =
             | None ->
                 failwith "the concrete memory model requires a complete implementation MIN"
           end
+      | Vaddr_t -> zero
       | Enum _ ->
           (* TODO: hack, assuming like int *)
           negate (pow_int (of_int 2) (8*4-1))

--- a/memory/symbolic/impl_mem.ml
+++ b/memory/symbolic/impl_mem.ml
@@ -68,7 +68,9 @@ module Constraints = struct
             [Symbol.mk_string ctx "_Unsigned_ity"] [Some integerBaseTypeSort]
             [0(*TODO: no idea with I'm doing*)]
         ; mk_ctor "size_t_ity"
-        ; mk_ctor "ptrdiff_t_ity" ] in
+        ; mk_ctor "ptrdiff_t_ity"
+        ; mk_ctor "vaddr_t_ity"
+        ] in
     
     let basicTypeSort =
       Datatype.mk_sort_s ctx "BasicType"
@@ -286,6 +288,8 @@ let integerType_to_expr slvSt (ity: Ctype.integerType) =
     | Size_t ->
         Expr.mk_app slvSt.ctx (List.nth fdecls 4) []
     | Ptrdiff_t ->
+        Expr.mk_app slvSt.ctx (List.nth fdecls 5) []
+    | Vaddr_t ->
         Expr.mk_app slvSt.ctx (List.nth fdecls 5) []
     | Wint_t
     | Wchar_t ->

--- a/memory/symbolic/mem_simplify.ml
+++ b/memory/symbolic/mem_simplify.ml
@@ -82,6 +82,8 @@ let rec simplify_integer_value_base ival_ =
                 | None ->
                     Right ival_
               end
+          | Vaddr_t ->
+              Left (of_int 0)
 
           | Signed ibty ->
               if not simple_fromptr && ibty = Intptr_t then
@@ -126,6 +128,8 @@ let rec simplify_integer_value_base ival_ =
                 | Ptrdiff_t
                 | Signed _ ->
                     Left signed_max
+                | Vaddr_t ->
+                    Left unsigned_max
                 | Enum _ ->
                     failwith "IVmax Enum"
                 | Wchar_t

--- a/memory/vip/common.ml
+++ b/memory/vip/common.ml
@@ -167,6 +167,8 @@ let ity_max ity =
           | Wint_t (* TODO *)
           | Signed _ ->
               signed_max
+          |  Vaddr_t ->
+              unsigned_max
           | Enum _ ->
               (* TODO: hack, assuming like int *)
               sub (pow_int (of_int 2) (8*4-1)) (of_int 1)
@@ -198,6 +200,7 @@ let ity_min ity =
           | None ->
               failwith "the VIP memory model requires a complete implementation MIN"
         end
+    | Vaddr_t -> zero
     | Enum _ ->
         (* TODO: hack, assuming like int *)
         negate (pow_int (of_int 2) (8*4-1))

--- a/ocaml_frontend/ocaml_implementation.ml
+++ b/ocaml_frontend/ocaml_implementation.ml
@@ -83,6 +83,8 @@ module DefaultImpl = struct
       | Ptrdiff_t ->
           (* STD §7.19#2 *)
           true
+      | Vaddr_t ->
+          false
 
   let sizeof_ity = function
     | Char
@@ -117,7 +119,9 @@ module DefaultImpl = struct
     | Size_t
     | Ptrdiff_t ->
         Some 8
-  
+    | Vaddr_t ->
+        Some 8
+
   (* NOTE: the code is bit generic here to allow reusability *)
   let precision_ity ity =
     match sizeof_ity ity with
@@ -169,6 +173,8 @@ module DefaultImpl = struct
         Some 4
     | Size_t
     | Ptrdiff_t ->
+        Some 8
+    | Vaddr_t ->
         Some 8
 
   let alignof_fty = function
@@ -315,7 +321,10 @@ module HafniumImpl = struct
     | Ptrdiff_t ->
         (* STD *)
         true
-  
+    | Vaddr_t ->
+        (* STD *)
+        false
+
   let sizeof_ity = function
     | Char ->
         Some 1
@@ -352,7 +361,9 @@ module HafniumImpl = struct
         Some 8
     | Ptrdiff_t ->
         Some 8
-  
+    | Vaddr_t ->
+        Some 8
+
   (* No trap representations *)
   let precision_ity ity =
     match sizeof_ity ity with
@@ -408,7 +419,9 @@ module HafniumImpl = struct
         Some 8
     | Ptrdiff_t ->
         Some 8
-  
+    | Vaddr_t ->
+        Some 8
+
   let alignof_fty = function
     | RealFloating Float ->
         Some 4
@@ -444,6 +457,7 @@ let hafniumIntImpl: IntegerImpl.implementation =
       | None   -> assert false)
   (Size_t)
   (Ptrdiff_t)
+  (Vaddr_t)
 
 
 (* TODO: this is horrible... *)

--- a/ocaml_frontend/pprinters/pp_ail.ml
+++ b/ocaml_frontend/pprinters/pp_ail.ml
@@ -173,6 +173,8 @@ let pp_integerType = function
      pp_type_keyword "wint_t"
  | Ptrdiff_t ->
      pp_type_keyword "ptrdiff_t"
+ | Vaddr_t ->
+     pp_type_keyword "vaddr_t"
  | Signed ibty ->
      pp_type_keyword "signed" ^^^ !^ (string_of_integerBaseType ibty)
  | Unsigned ibty ->
@@ -198,6 +200,8 @@ let macro_string_of_integerType = function
      "WINT"
  | Ptrdiff_t ->
      "PTRDIFF"
+ | Vaddr_t ->
+     "VADDR"
  | Enum sym ->
      (* NOTE: this is hackish, these don't exists in C11 *)
      "ENUM_" ^ Pp_symbol.to_string_pretty sym
@@ -861,6 +865,8 @@ let rec pp_genIntegerType = function
       !^ "size_t"
   | PtrdiffT ->
       !^ "ptrdiff_t"
+  | VaddrT ->
+      !^ "vaddr_t"
   | Unknown iCst ->
       !^ "unknown constant" ^^^ P.brackets (pp_integerConstant iCst)
   | Promote gity ->

--- a/ocaml_frontend/pprinters/pp_ail_ast.ml
+++ b/ocaml_frontend/pprinters/pp_ail_ast.ml
@@ -92,6 +92,8 @@ let rec pp_genIntegerType_raw = function
      !^ "SizeT"
  | PtrdiffT ->
      !^ "PtrdiffT"
+ | VaddrT ->
+     !^ "VaddrT"
  | Unknown iCst ->
      !^ "Unknown" ^^ P.brackets (Pp_ail.pp_integerConstant iCst)
  | Promote gity ->

--- a/ocaml_frontend/pprinters/pp_ail_raw.ml
+++ b/ocaml_frontend/pprinters/pp_ail_raw.ml
@@ -57,6 +57,8 @@ let pp_integerType_raw = function
      pp_ctor "Wint_t"
  | Ptrdiff_t ->
      pp_ctor "Ptrdiff_t"
+ | Vaddr_t ->
+     pp_ctor "Vaddr_t"
 
 
 

--- a/ocaml_frontend/pprinters/pp_core_ctype.ml
+++ b/ocaml_frontend/pprinters/pp_core_ctype.ml
@@ -44,6 +44,7 @@ let pp_integer_ctype ?(compact = false) ity =
     | Wchar_t          -> !^ "wchar_t"
     | Wint_t           -> !^ "wint_t"
     | Ptrdiff_t        -> !^ "ptrdiff_t"
+    | Vaddr_t          -> !^ "vaddr_t"
 
 let pp_floating_ctype fty =
   match fty with


### PR DESCRIPTION
Added new CHERI-specific integer type `vaddr_t`.
It is always unsigned and has the range to hold memory addresses (e.g. 64 bits on int64).