### PR TITLE
CHERI: Prove `memcpy_data_PreservesInvariant`

### DIFF
--- a/coq/Proofs/ProofsAux.v
+++ b/coq/Proofs/ProofsAux.v
@@ -1855,17 +1855,16 @@ Section AddressValue_Lemmas.
     apply ProofIrrelevance.proof_irrelevance.
   Qed.
 
-  Fact aligned_addr_neq_space :
-    forall addr addr' psize,
-      psize = alignof_pointer MorelloImpl.get ->
-      addr_ptr_aligned addr ->
-      addr_ptr_aligned addr' ->
-      addr <> addr' ->
-      (AddressValue.to_Z addr + Z.of_nat psize <= AddressValue.to_Z addr')
-      \/
-      (AddressValue.to_Z addr' + Z.of_nat psize <= AddressValue.to_Z addr).
+  Fact aligned_addr_neq_space (addr addr' : AddressValue.t) (psize : nat) :
+    psize = alignof_pointer MorelloImpl.get ->
+    addr_ptr_aligned addr ->
+    addr_ptr_aligned addr' ->
+    addr <> addr' ->
+    (AddressValue.to_Z addr + Z.of_nat psize <= AddressValue.to_Z addr')
+    \/
+    (AddressValue.to_Z addr' + Z.of_nat psize <= AddressValue.to_Z addr).
   Proof.
-    intros * SZ A A' NEQ.
+    intros SZ A A' NEQ.
     unfold addr_ptr_aligned in *.
     apply AddressValue_neq_via_to_Z in NEQ.
     subst.
@@ -1881,6 +1880,25 @@ Section AddressValue_Lemmas.
     subst.
     enough ((a1 + 1) <= a2 \/ (a2 + 1) <= a1) by nia.
     nia.
+  Qed.
+
+  Fact aligned_addr_lt_space (addr addr' : AddressValue.t) (psize : nat) :
+    psize = alignof_pointer MorelloImpl.get ->
+    addr_ptr_aligned addr ->
+    addr_ptr_aligned addr' ->
+    AddressValue.ltb addr addr' = true ->
+    AddressValue.to_Z addr + Z.of_nat psize <= AddressValue.to_Z addr'.
+  Proof.
+    intros SZ A A' LT.
+    rewrite AddressValue_ltb_Z_ltb, Z.ltb_lt in LT.
+    pose proof aligned_addr_neq_space addr addr' psize as SPC.
+    full_autospecialize SPC; auto.
+    -
+      clear - LT.
+      intros C; subst addr'.
+      lia.
+    -
+      lia.
   Qed.
 
   Fact max_aligned (addr : AddressValue.t) :

--- a/coq/Proofs/Revocation.v
+++ b/coq/Proofs/Revocation.v
@@ -6552,16 +6552,16 @@ Module CheriMemoryImplWithProofs
     unfold memcpy_copy_data.
     induction n.
     -
-      intros s _.
+      intros s _ _.
       preserves_step.
       cbn.
       unfold mem_state_with_bytemap.
       destruct s.
       auto.
     -
-      intros s CIN.
-      preserves_steps.
-      rename H into M.
+      intros s CIN LIM.
+      preserves_steps;
+        rename H into M.
       +
         (* adding *)
         split.
@@ -7377,6 +7377,20 @@ Module CheriMemoryImplWithProofs
               invc H0.
               reflexivity.
           }
+          autospecialize P.
+          {
+            subst.
+            destruct H2 as [MIbase MIcap].
+            destruct_base_mem_invariant MIbase.
+            clear - AC Bfit.
+            invc AC.
+            clear H3 H5 H8.
+            apply Bfit in H2.
+            invc H9.
+            unfold cap_to_Z in *.
+            lia.
+          }
+          
           specialize (P H2).
 
           unfold post_exec_invariant, lift_sum_p, execErrS in P.

--- a/coq/Proofs/Revocation.v
+++ b/coq/Proofs/Revocation.v
@@ -6537,9 +6537,6 @@ Module CheriMemoryImplWithProofs
     (n: nat)
     :
     forall s,
-
-      (* TODO: assume input to copy_data is output of ghost_tags *)
-
       (* In *)
       (forall a : AddressValue.t,
           let alignment := Z.of_nat (alignof_pointer MorelloImpl.get) in
@@ -6549,7 +6546,7 @@ Module CheriMemoryImplWithProofs
           forall (tg : bool) (gs : CapGhostState),
             AMap.M.MapsTo a (tg, gs) (capmeta s) ->
             tg = false \/ tag_unspecified gs = true) ->
-
+      AddressValue.to_Z dst_a + Z.of_nat n <= AddressValue.ADDR_LIMIT ->
       PreservesInvariant mem_invariant s (memcpy_copy_data loc dst_a src_a n).
   Proof.
     unfold memcpy_copy_data.

--- a/coq/Proofs/Revocation.v
+++ b/coq/Proofs/Revocation.v
@@ -5488,15 +5488,16 @@ Module CheriMemoryImplWithProofs
     (bm : AMap.M.t (option ascii))
     (bs : list (option ascii))
     (szn : nat) :
-    szn = Datatypes.length bs ->
+    let len := Datatypes.length bs in
+    AddressValue.to_Z start + Z.of_nat len <= AddressValue.ADDR_LIMIT ->
     AddressValue.to_Z addr + Z.of_nat szn <= AddressValue.ADDR_LIMIT ->
-    AddressValue.to_Z start + Z.of_nat szn <= AddressValue.ADDR_LIMIT ->
     (AddressValue.to_Z addr + Z.of_nat szn <= AddressValue.to_Z start \/
-       AddressValue.to_Z (AddressValue.with_offset start (Z.of_nat (Datatypes.length bs) - 1)) <
+       AddressValue.to_Z (AddressValue.with_offset start (Z.of_nat len - 1)) <
          AddressValue.to_Z addr) ->
     fetch_bytes (AMap.map_add_list_at bm bs start) addr szn = fetch_bytes bm addr szn.
   Proof.
-    intros SZN AL SL NE.
+    intros len LL AL NE.
+    subst len.
     unfold fetch_bytes.
     apply map_ext_in; intros aoff AOFF.
     enough (T : AMap.M.find (elt:=option ascii) aoff bm
@@ -5519,6 +5520,7 @@ Module CheriMemoryImplWithProofs
     }
     clear AOFF; rename AOFF' into AOFF.
     rewrite !AddressValue_ltb_Z_ltb, !Z.ltb_lt.
+    subst.
     lia.
   Qed.
 


### PR DESCRIPTION
Everything in this PR is required to prove `memcpy_data_PreservesInvariant`

While not strictly necessary (I think I could have proven the original lemma by utilizing the fact that overflow wraps), I have limited the statement (see 38766991b315448aec74e84fd334fb853112d6af) to only those cases where copied data fits within bounds.

This was not originally assumed, though a stronger assumption ([`mempcpy_args_sane`](https://github.com/zoickx/cerberus/blob/0335b97257240ab4c5bb7b72303344a7a24c0392/coq/Proofs/Revocation.v#L7296)) is present in other memcpy lemmas, which allowed me to resolve all new goals that popped up.

Not sure if this change is the best way to go or even correct, though it did not introduce any new admits.